### PR TITLE
:sparkles: feat : SpringSecurity 다중 로그인 구현

### DIFF
--- a/src/main/java/roomit/web1_2_bumblebee_be/domain/business/controller/BusinessController.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/domain/business/controller/BusinessController.java
@@ -4,6 +4,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import roomit.web1_2_bumblebee_be.domain.business.entity.Business;
+import roomit.web1_2_bumblebee_be.domain.business.exception.BusinessNotFound;
+import roomit.web1_2_bumblebee_be.domain.business.repository.BusinessRepository;
+import roomit.web1_2_bumblebee_be.domain.business.request.BusinessRegisterRequest;
 import roomit.web1_2_bumblebee_be.domain.business.request.BusinessUpdateRequest;
 import roomit.web1_2_bumblebee_be.domain.business.response.BusinessResponse;
 import roomit.web1_2_bumblebee_be.domain.business.service.BusinessService;
@@ -14,6 +18,15 @@ import roomit.web1_2_bumblebee_be.domain.business.service.BusinessService;
 public class BusinessController {
 
     private final BusinessService businessService;
+
+    //사업자 회원 가입
+    @PostMapping("/api/v1/business/signup")
+    public ResponseEntity<String> signup(@RequestBody @Valid BusinessRegisterRequest request) {
+        businessService.signUpBusiness(request);
+
+        return ResponseEntity.status(200).body("사업자 회원 등록이 완료되었습니다.");
+    }
+
 
     //사업자 정보 수정
     @PutMapping("api/v1/business/update")

--- a/src/main/java/roomit/web1_2_bumblebee_be/domain/business/repository/BusinessRepository.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/domain/business/repository/BusinessRepository.java
@@ -1,10 +1,17 @@
 package roomit.web1_2_bumblebee_be.domain.business.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import roomit.web1_2_bumblebee_be.domain.business.entity.Business;
+import roomit.web1_2_bumblebee_be.domain.business.entity.value.BusinessEmail;
 
 import java.util.Optional;
 
 public interface BusinessRepository extends JpaRepository<Business, Long> {
-    Optional<Business> findByBusinessEmail(String email);
+
+
+    @Query("SELECT b FROM Business b WHERE b.businessEmail.value = :email")
+    Business findByEmail(@Param("email") String email);
 }
+

--- a/src/main/java/roomit/web1_2_bumblebee_be/domain/business/response/CustomBusinessDetails.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/domain/business/response/CustomBusinessDetails.java
@@ -1,0 +1,67 @@
+package roomit.web1_2_bumblebee_be.domain.business.response;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import roomit.web1_2_bumblebee_be.domain.business.entity.Business;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class CustomBusinessDetails implements UserDetails {
+
+    private final Business business;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+
+        authorities.add(new SimpleGrantedAuthority(business.getBusinessRole().name()));
+
+        return authorities;
+    }
+
+
+    @Override
+    public String getPassword() {
+
+        return business.getBusinessPwd().getValue();
+    }
+
+    public Long getId(){ //member의 id값 가져오기
+
+        return business.getBusinessId();
+    }
+
+    @Override
+    public String getUsername() {
+
+        return business.getBusinessEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+}

--- a/src/main/java/roomit/web1_2_bumblebee_be/domain/business/service/CustomBusinessDetailsService.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/domain/business/service/CustomBusinessDetailsService.java
@@ -1,0 +1,32 @@
+package roomit.web1_2_bumblebee_be.domain.business.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import roomit.web1_2_bumblebee_be.domain.business.entity.Business;
+import roomit.web1_2_bumblebee_be.domain.business.repository.BusinessRepository;
+import roomit.web1_2_bumblebee_be.domain.business.response.CustomBusinessDetails;
+import roomit.web1_2_bumblebee_be.domain.member.dto.CustomMemberDetails;
+import roomit.web1_2_bumblebee_be.domain.member.entity.Member;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class CustomBusinessDetailsService implements UserDetailsService {
+
+    private final BusinessRepository businessRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Business business = businessRepository.findByEmail(email);
+
+        if (business != null){
+
+            return new CustomBusinessDetails(business);
+        }
+        return null;
+    }
+}

--- a/src/main/java/roomit/web1_2_bumblebee_be/domain/member/service/MemberService.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/domain/member/service/MemberService.java
@@ -14,14 +14,12 @@ import roomit.web1_2_bumblebee_be.domain.member.repository.MemberRepository;
 
 @Service
 @RequiredArgsConstructor
-@Log4j2
 public class MemberService {
 
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     public void signupMember(MemberRegisterRequest memberRequest) {
-        log.info(memberRequest.getNickName());
         Member member = Member.builder()
                 .memberAge(memberRequest.getAge())
                 .memberSex(memberRequest.getSex())

--- a/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/SpringSecurityConfig.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/SpringSecurityConfig.java
@@ -3,11 +3,15 @@ package roomit.web1_2_bumblebee_be.global.config.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -19,6 +23,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
+import roomit.web1_2_bumblebee_be.domain.business.service.CustomBusinessDetailsService;
+import roomit.web1_2_bumblebee_be.domain.member.service.CustomMemberDetailsService;
 import roomit.web1_2_bumblebee_be.global.config.security.jwt.JWTFilter;
 import roomit.web1_2_bumblebee_be.global.config.security.jwt.JWTUtil;
 import roomit.web1_2_bumblebee_be.global.config.security.jwt.LoginFilter;
@@ -33,11 +39,15 @@ public class SpringSecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JWTUtil jwtUtil;
+    private final CustomMemberDetailsService memberDetailsService;
+    private final CustomBusinessDetailsService businessDetailsService;
 
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-
-        return configuration.getAuthenticationManager();
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        return http.getSharedObject(AuthenticationManagerBuilder.class)
+                .authenticationProvider(memberAuthenticationProvider())
+                .authenticationProvider(businessAuthenticationProvider())
+                .build();
     }
 
     @Bean
@@ -52,6 +62,22 @@ public class SpringSecurityConfig {
                 ROLE_ADMIN > ROLE_BUSINESS
                 ROLE_BUSINESS > ROLE_USER
                 """);
+    }
+
+    @Bean
+    public DaoAuthenticationProvider memberAuthenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(memberDetailsService);
+        provider.setPasswordEncoder(bCryptPasswordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public DaoAuthenticationProvider businessAuthenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(businessDetailsService);
+        provider.setPasswordEncoder(bCryptPasswordEncoder());
+        return provider;
     }
 
     @Bean
@@ -83,20 +109,19 @@ public class SpringSecurityConfig {
         http
                 // 경로별 인가 작업
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login","/").permitAll()
+                        .requestMatchers("/login/**","/").permitAll()
                         .requestMatchers("/api/v1/member/signup").permitAll()
-                        .requestMatchers("/admin").hasRole("ADMIN") //ADMIN권한만 사용 가능
-                        .requestMatchers("/business").hasRole("BUSINESS") //ADMIN권한만 사용 가능
-                        .requestMatchers("/user").hasRole("USER") //USER권한만 사용 가능
-                        .anyRequest().authenticated()); // permitAll()로 할시 모두 허용
+                        .requestMatchers("/api/v1/business/signup").permitAll()
+                        .anyRequest().permitAll()); // permitAll()로 할시 모두 허용
 
         http
                 //JWT 필터 추가
                 .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
 
-         http
+        http
                 //커스텀 로그인 필터 추가
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration),jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(http), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
 
         http
                 // 세션 설정
@@ -106,6 +131,7 @@ public class SpringSecurityConfig {
 
 
         return http.build();
-
     }
+
+
 }

--- a/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/JWTFilter.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/JWTFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -16,6 +17,7 @@ import roomit.web1_2_bumblebee_be.domain.member.entity.Role;
 import java.io.IOException;
 
 @RequiredArgsConstructor
+@Log4j2
 public class JWTFilter extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
@@ -25,6 +27,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String authorization = request.getHeader("Authorization");
 
+        log.info("token: " +authorization);
         // Authorization 헤더 검증
         if (authorization == null || !authorization.startsWith("Bearer ")){
 
@@ -45,6 +48,10 @@ public class JWTFilter extends OncePerRequestFilter {
         //토큰에서 값 획득
         String email = jwtUtil.getUsername(token);
         Role role = jwtUtil.getRole(token);
+
+        log.info("email : " + email);
+        log.info("role : " + role);
+
 
         //Member 엔티티 생성하여 값 set
         Member member = Member.builder()
@@ -70,6 +77,10 @@ public class JWTFilter extends OncePerRequestFilter {
             return true;
         }
         if (request.getRequestURI().startsWith("/api/v1/member/signup")) {
+
+            return true;
+        }
+        if (request.getRequestURI().startsWith("/api/v1/business/signup")) {
 
             return true;
         }

--- a/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/LoginFilter.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/LoginFilter.java
@@ -1,21 +1,23 @@
 package roomit.web1_2_bumblebee_be.global.config.security.jwt;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import roomit.web1_2_bumblebee_be.domain.business.response.CustomBusinessDetails;
 import roomit.web1_2_bumblebee_be.domain.member.dto.CustomMemberDetails;
-
-import java.util.Collection;
-import java.util.Iterator;
+import roomit.web1_2_bumblebee_be.global.config.security.jwt.token.BusinessAuthenticationToken;
+import roomit.web1_2_bumblebee_be.global.config.security.jwt.token.MemberAuthenticationToken;
 
 @RequiredArgsConstructor
+@Log4j2
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
@@ -24,31 +26,43 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
 
-        String email = request.getParameter("email"); // email 필드 추출
-        String password = request.getParameter("password"); // password 필드 추출
+        String email = request.getParameter("email");
+        String password = request.getParameter("password");
 
-        UsernamePasswordAuthenticationToken authenticationToken
-                = new UsernamePasswordAuthenticationToken(email,password,null);
+        // 요청 URI로 멤버와 사업자 구분
+        String requestUri = request.getRequestURI();
+        Authentication authenticationToken;
 
-        return authenticationManager.authenticate(authenticationToken);
+        if (requestUri.equals("/login/member")) {
+            // 멤버 인증 토큰 생성
+            authenticationToken = new MemberAuthenticationToken(email, password);
+        } else if (requestUri.equals("/login/business")) {
+            // 사업자 인증 토큰 생성
+            authenticationToken = new BusinessAuthenticationToken(email, password);
+        } else {
+            throw new AuthenticationServiceException("Invalid login endpoint");
+        }
+
+        // 인증 시도
+        return getAuthenticationManager().authenticate(authenticationToken);
+
     }
 
     //로그인 성공시 실행하는 메서드 (JWT발급)
     @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
-        CustomMemberDetails customMemberDetails = (CustomMemberDetails) authentication.getPrincipal();
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws ServletException {
+        String token;
+        if (authentication.getPrincipal() instanceof CustomMemberDetails) {
+            CustomMemberDetails memberDetails = (CustomMemberDetails) authentication.getPrincipal();
+            token = jwtUtil.createJwt(memberDetails.getUsername(), "ROLE_USER", 1000 * 60 * 60L);  // 멤버의 JWT
+        } else if (authentication.getPrincipal() instanceof CustomBusinessDetails) {
+            CustomBusinessDetails businessDetails = (CustomBusinessDetails) authentication.getPrincipal();
+            token = jwtUtil.createJwt(businessDetails.getUsername(), "ROLE_BUSINESS", 1000 * 60 * 60L);  // 사업자의 JWT
+        } else {
+            throw new ServletException("Unknown authentication type");
+        }
 
-        String username = customMemberDetails.getUsername();
-
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        Iterator<? extends  GrantedAuthority> iterator = authorities.iterator();
-        GrantedAuthority auth = iterator.next();
-
-        String role = auth.getAuthority();
-
-        String token = jwtUtil.createJwt(username,role,1000*60*60L); //jwt 생성
-
-        response.addHeader("Authorization", "Bearer " + token); //헤더에 추가 Bearer 인증 방식
+        response.addHeader("Authorization", "Bearer " + token);
     }
 
     //로그인 실패시 실행하는 메서드

--- a/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/controller/LoginController.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/controller/LoginController.java
@@ -1,0 +1,67 @@
+package roomit.web1_2_bumblebee_be.global.config.security.jwt.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import roomit.web1_2_bumblebee_be.domain.business.response.CustomBusinessDetails;
+import roomit.web1_2_bumblebee_be.domain.member.dto.CustomMemberDetails;
+import roomit.web1_2_bumblebee_be.global.config.security.jwt.JWTUtil;
+import roomit.web1_2_bumblebee_be.global.config.security.jwt.dto.LoginRequest;
+import roomit.web1_2_bumblebee_be.global.config.security.jwt.dto.LoginResponse;
+
+@RestController
+@RequestMapping("/login")
+@RequiredArgsConstructor
+@Log4j2
+public class LoginController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+
+    @PostMapping("/member")
+    public ResponseEntity<?> memberLogin(@RequestBody LoginRequest loginRequest) {
+        log.info(loginRequest.getEmail());
+        try {
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword());
+
+            Authentication authentication = authenticationManager.authenticate(authenticationToken);
+            CustomMemberDetails memberDetails = (CustomMemberDetails) authentication.getPrincipal();
+
+            // JWT 생성
+            String jwt = jwtUtil.createJwt(memberDetails.getUsername(), "ROLE_USER", 1000 * 60 * 60L);
+            return ResponseEntity.ok(new LoginResponse(jwt));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid credentials");
+        }
+    }
+
+    @PostMapping("/business")
+    public ResponseEntity<?> businessLogin(@RequestBody LoginRequest loginRequest) {
+        log.info(loginRequest.getEmail());
+        log.info(loginRequest.getPassword());
+        try {
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword());
+
+            Authentication authentication = authenticationManager.authenticate(authenticationToken);
+            CustomBusinessDetails businessDetails = (CustomBusinessDetails) authentication.getPrincipal();
+
+            // JWT 생성
+            String jwt = jwtUtil.createJwt(businessDetails.getUsername(), "ROLE_BUSINESS", 1000 * 60 * 60L);
+            return ResponseEntity.ok(new LoginResponse(jwt));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid credentials");
+        }
+    }
+}

--- a/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/dto/LoginRequest.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package roomit.web1_2_bumblebee_be.global.config.security.jwt.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/dto/LoginResponse.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/dto/LoginResponse.java
@@ -1,0 +1,10 @@
+package roomit.web1_2_bumblebee_be.global.config.security.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginResponse {
+    private String token;
+}

--- a/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/token/BusinessAuthenticationToken.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/token/BusinessAuthenticationToken.java
@@ -1,0 +1,28 @@
+package roomit.web1_2_bumblebee_be.global.config.security.jwt.token;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collections;
+
+public class BusinessAuthenticationToken extends AbstractAuthenticationToken {
+    private final String email;
+    private final String password;
+
+    public BusinessAuthenticationToken(String email, String password) {
+        super(Collections.singletonList(new SimpleGrantedAuthority("ROLE_BUSINESS")));
+        this.email = email;
+        this.password = password;
+        setAuthenticated(false);  // 인증되지 않은 상태로 시작
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.password;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.email;
+    }
+}

--- a/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/token/MemberAuthenticationToken.java
+++ b/src/main/java/roomit/web1_2_bumblebee_be/global/config/security/jwt/token/MemberAuthenticationToken.java
@@ -1,0 +1,28 @@
+package roomit.web1_2_bumblebee_be.global.config.security.jwt.token;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collections;
+
+public class MemberAuthenticationToken extends AbstractAuthenticationToken {
+    private final String email;
+    private final String password;
+
+    public MemberAuthenticationToken(String email, String password) {
+        super(Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+        this.email = email;
+        this.password = password;
+        setAuthenticated(false);  // 인증되지 않은 상태로 시작
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.password;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.email;
+    }
+}


### PR DESCRIPTION
## 🛠️ 과제 요약 
- SpringSecurity 다중 로그인 구현

## 📝 요구 사항과 구현 내용
- SpringSecurity Provider를 통해 로그인 로직을 분리하였습니다 (멤버/사업자 로그인)
> memberAuthenticationProvider와businessAuthenticationProvider로 나눠 요청값의 url로 나눠 business로그인시 business테이블을, member로그인시 member테이블을 조회하여 로그인합니다
- 로그인 로직을 분리하며 CustomUserDetailes를 business와member로 분리하였습니다
- BusinessControllr의 회원 가입을 추가하였습니다
- business의 Embedded 필드의 경우 repository에서 따로 쿼리문을 작성하여 맞는 타입으로 반환받아야 하는 경우가 생겨 수정하였습니다 (첨부1)


## 💬 PR 포인트 & 궁금한 점
- 시큐리티를 처음 작업하는데 다른분들은 멀티 로그인을 구현하면 어떤식으로 할지 궁금합니다 (너무 힘들었네요..)

## 🔗 연관된 이슈
- #34 

## 이미지 첨부
-첨부1
![image](https://github.com/user-attachments/assets/da06778a-300c-49f2-920f-44cbf8450c7d)

##참고 사항
- Member을 수정하시면서 repository부분을 (첨부1)처럼 변경 안하며 오류 발생합니다!

## 추후 구현 사항
1. 이중 토큰 구현
2. 테스트 코드 구현

