### PR TITLE
Feature/77 테스트툴연결 docker

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,0 +1,38 @@
+networks:
+  k6:
+  grafana:
+
+services:
+  influxdb:
+    image: influxdb:1.8
+    networks:
+      - k6
+      - grafana
+    ports:
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=k6
+
+  grafana:
+    image: grafana/grafana:9.3.8
+    networks:
+      - grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    volumes:
+      - ./grafana:/etc/grafana/provisioning/
+
+  k6:
+    image: grafana/k6:latest
+    networks:
+      - k6
+    ports:
+      - "6565:6565"
+    environment:
+      - K6_OUT=influxdb=http://influxdb:8086/k6
+    volumes:
+      - C:/Git/WEB1_2_BUMBLEBEE_BE/.github/k6-scripts:/scripts

--- a/.github/k6-scripts/test-script.js
+++ b/.github/k6-scripts/test-script.js
@@ -1,0 +1,13 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+
+export const options = {
+  vus: 20, // 가상 사용자 수
+  duration: '30s', //테스트 시간
+};
+
+export default function () {
+  http.get('http://host.docker.internal:8080/api/v1/business')
+  sleep(1);
+}

--- a/src/main/java/roomit/main/global/config/security/SpringSecurityConfig.java
+++ b/src/main/java/roomit/main/global/config/security/SpringSecurityConfig.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 테스트툴연결 docker

## 📝 요구 사항과 구현 내용
-  k6+grafana+influxDB docker-compose.yml 파일 생성
-  k6 예시 파일 생성

## ✅ 피드백 반영사항
- 피드백 받은 내용과 반영된 결과 적기

## 💬 PR 포인트 & 궁금한 점
- ## Test tool 사용 방법

docker-compse.yml 파일이 있는 곳에서 powershell에 입력

grfana, influxdb 실행

`docker-compose up -d influxdb grafana`

k6 테스트 실행

 `docker-compose run k6 run /scripts/{실행할 js 파일}`

참고 [링크](https://velog.io/@prismy/%EC%84%B1%EB%8A%A5-%ED%85%8C%EC%8A%A4%ED%8A%B8-k6grafanainfluxDB-%EC%8D%A8%EB%B3%B4%EA%B8%B0)

## 🔗 연관된 이슈
- 열린 이슈를 닫고싶으면 
- close #이슈번호 [이슈제목]
- 이슈를 닫지 않을 거라면 작성X