### PR TITLE
:recycle: refactor : member 리팩토링

### DIFF
--- a/src/main/java/roomit/main/domain/business/dto/response/BusinessResponse.java
+++ b/src/main/java/roomit/main/domain/business/dto/response/BusinessResponse.java
@@ -8,7 +8,7 @@ public record BusinessResponse (
     String businessName,
     String businessEmail,
     String businessNum,
-    LocalDateTime createAt
+    LocalDateTime createdAt
 ){
 
     public BusinessResponse(Business business) {

--- a/src/main/java/roomit/main/domain/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/roomit/main/domain/member/dto/request/MemberUpdateRequest.java
@@ -1,11 +1,15 @@
 package roomit.main.domain.member.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
+import roomit.main.domain.member.entity.Sex;
 import roomit.main.domain.member.entity.value.MemberEmail;
 import roomit.main.domain.member.entity.value.MemberNickname;
-import roomit.main.domain.member.entity.value.MemberPassword;
 import roomit.main.domain.member.entity.value.MemberPhoneNumber;
+
+import java.time.LocalDate;
 
 
 public record MemberUpdateRequest(
@@ -15,8 +19,10 @@ public record MemberUpdateRequest(
         String phoneNumber,
         @Pattern(regexp = MemberEmail.REGEX, message = MemberEmail.ERR_MSG)
         String email,
-        @Pattern(regexp = MemberPassword.REGEX, message = MemberPassword.ERR_MSG)
-        String pwd
+        @NotNull(message = "생년월일은 필수 입력 값입니다.")
+        LocalDate birthDay,
+        @NotNull(message = "성별은 필수 입력 값입니다.")
+        Sex sex
 ) {
     @Builder
     public MemberUpdateRequest {

--- a/src/main/java/roomit/main/domain/member/entity/Member.java
+++ b/src/main/java/roomit/main/domain/member/entity/Member.java
@@ -53,14 +53,13 @@ public class Member {
     @Enumerated(value = EnumType.STRING)
     private Role memberRole;
 
-    @Column(name = "birth_day", nullable = false)
+    @Column(name = "birth_day")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate birthDay;
 
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
     private LocalDateTime deleteAt;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -105,5 +104,11 @@ public class Member {
     }
     public void changePwd(String newPwd) {
         this.memberPwd = new MemberPassword(newPwd, new BCryptPasswordEncoder());
+    }
+    public void changeSex(Sex newSex) {
+        this.memberSex = newSex;
+    }
+    public void changeBirthDay(LocalDate newBirthDay){
+        this.birthDay = newBirthDay;
     }
 }

--- a/src/main/java/roomit/main/domain/member/service/MemberService.java
+++ b/src/main/java/roomit/main/domain/member/service/MemberService.java
@@ -46,7 +46,8 @@ public class MemberService {
             member.changeEmail(request.email());
             member.changeNickName(request.nickName());
             member.changePhoneNumber(request.phoneNumber());
-            member.changePwd(request.pwd());
+            member.changeSex(request.sex());
+            member.changeBirthDay(request.birthDay());
             memberRepository.save(member);
 
         }catch (Exception e){

--- a/src/main/java/roomit/main/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/roomit/main/domain/oauth2/service/CustomOAuth2UserService.java
@@ -58,7 +58,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (existData == null){
             Member data = Member.builder()
                     .memberRole(Role.ROLE_USER)
-                    .birthDay(LocalDate.now())
                     .memberSex(Sex.MALE)
                     .memberPhoneNumber("010-1212-3232")
                     .memberPwd("TestPwd12!")

--- a/src/test/java/roomit/main/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/roomit/main/domain/member/controller/MemberControllerTest.java
@@ -24,6 +24,7 @@ import roomit.main.domain.token.dto.LoginResponse;
 import roomit.main.global.error.ErrorCode;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -177,10 +178,11 @@ class MemberControllerTest {
 
 
         MemberUpdateRequest memberRequest = MemberUpdateRequest.builder()
-                .pwd("Business2!")
+                .sex(Sex.MALE)
                 .email("sdsd@naver.com")
                 .phoneNumber("010-3323-2323")
                 .nickName("이이")
+                .birthDay(LocalDate.parse("1999-01-01"))
                 .build();
 
         String json = objectMapper.writeValueAsString(memberRequest);
@@ -199,7 +201,6 @@ class MemberControllerTest {
         Member member1 = memberRepository.findByMemberEmail("sdsd@naver.com")
                 .orElseThrow(ErrorCode.MEMBER_NOT_FOUND::commonException);
 
-        Assertions.assertTrue(bCryptPasswordEncoder.matches("Business2!", member1.getMemberPwd()));
     }
 
     @Test

--- a/src/test/java/roomit/main/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/roomit/main/domain/member/service/MemberServiceTest.java
@@ -20,6 +20,7 @@ import roomit.main.domain.workplace.repository.WorkplaceRepository;
 import roomit.main.global.error.ErrorCode;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -119,17 +120,19 @@ class MemberServiceTest {
         memberRepository.save(member);
 
         MemberUpdateRequest memberRequest = MemberUpdateRequest.builder()
-                .pwd("Business2!")
+                .sex(Sex.MALE)
                 .email("sdsd@naver.com")
                 .phoneNumber("010-3323-2323")
                 .nickName("이이")
+                .birthDay(LocalDate.parse("1999-01-01"))
                 .build();
 
 
 
         MemberResponse myDate = memberService.update(member.getMemberId(), memberRequest);
 
-        assertTrue(bCryptPasswordEncoder.matches("Business2!", myDate.pwd()));
+        assertEquals(memberRequest.sex(),myDate.sex());
+        assertEquals(memberRequest.birthDay(),myDate.birthDay());
 
     }
 


### PR DESCRIPTION
## 🛠️ 과제 요약 
- refactor : member 리팩토링

## 📝 요구 사항과 구현 내용
- Oauth 최초 데이터 베이스 저장값 생년월일은 null
- 회원 정보 수정 DTO pwd 제외 및 생년월일 성별 추가
- 생년월일 null값 허용
- BusinessResponse 필드의 createAt -> createdAt

## 🔗 연관된 이슈
- #95 