### PR TITLE
BugFix : 사업장 생성 시 스터디룸 등록 오류 시 예외처리

### DIFF
--- a/src/main/java/roomit/main/global/error/ErrorCode.java
+++ b/src/main/java/roomit/main/global/error/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 
     /*StudyRoom*/
     STUDYROOM_NOT_FOUND(HttpStatus.BAD_REQUEST,"S001","존재하지 않는 스터디룸입니다."),
+    STYDYROOM_NOT_REGISTERD(HttpStatus.UNAUTHORIZED, "S002","스터디름 등록에 실패하였습니다."),
 
     /*Business*/
     BUSINESS_NOT_FOUND(HttpStatus.BAD_REQUEST, "B003", "존재 하지 않는 사업자입니다."),

--- a/src/test/java/roomit/main/domain/workplace/controller/WorkplaceControllerTest.java
+++ b/src/test/java/roomit/main/domain/workplace/controller/WorkplaceControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import roomit.main.domain.business.dto.request.BusinessRegisterRequest;
 import roomit.main.domain.business.entity.Business;
 import roomit.main.domain.business.repository.BusinessRepository;
+import roomit.main.domain.studyroom.dto.request.CreateStudyRoomRequest;
 import roomit.main.domain.token.dto.LoginRequest;
 import roomit.main.domain.token.dto.LoginResponse;
 import roomit.main.domain.workplace.dto.request.WorkplaceGetRequest;
@@ -136,7 +137,7 @@ public class WorkplaceControllerTest {
     @Order(1)
     @Test
     @DisplayName("사업장 등록")
-    void create() throws Exception {
+    void createWithMockMvc() throws Exception {
         // Given
         WorkplaceRequest workplace = WorkplaceRequest.builder()
                 .workplaceName("사업장1")
@@ -146,20 +147,36 @@ public class WorkplaceControllerTest {
                 .imageUrl("http://image.url")
                 .workplaceStartTime(LocalTime.of(9, 0))
                 .workplaceEndTime(LocalTime.of(18, 0))
+                .studyRoomList(Arrays.asList(
+                        new CreateStudyRoomRequest(
+                                "Room A",
+                                "작은 룸",
+                                "http://default-image.url",
+                                7000,
+                                4
+                        ),
+                        new CreateStudyRoomRequest(
+                                "Room B",
+                                "큰 룸",
+                                "http://default-image.url",
+                                8000,
+                                6
+                        )
+                ))
                 .build();
 
         String json = objectMapper.writeValueAsString(workplace);
 
         // When
         mockMvc.perform(post("/api/v1/workplace")
-                        .header("Authorization", "Bearer " + token) // 토큰 추가
+                        .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(json))
-
                 // Then
                 .andExpect(status().isCreated())
                 .andDo(print());
     }
+
 
     @Order(2)
     @Test

--- a/src/test/java/roomit/main/domain/workplace/service/WorkplaceServiceTest.java
+++ b/src/test/java/roomit/main/domain/workplace/service/WorkplaceServiceTest.java
@@ -8,6 +8,7 @@ import roomit.main.domain.business.dto.request.BusinessRegisterRequest;
 import roomit.main.domain.business.entity.Business;
 import roomit.main.domain.business.repository.BusinessRepository;
 import roomit.main.domain.business.service.BusinessService;
+import roomit.main.domain.studyroom.dto.request.CreateStudyRoomRequest;
 import roomit.main.domain.workplace.dto.request.WorkplaceGetRequest;
 import roomit.main.domain.workplace.dto.request.WorkplaceRequest;
 import roomit.main.domain.workplace.dto.response.WorkplaceGetResponse;
@@ -112,6 +113,22 @@ class WorkplaceServiceTest {
                 .imageUrl("http://image.url")
                 .workplaceStartTime(LocalTime.of(9, 0))
                 .workplaceEndTime(LocalTime.of(18, 0))
+                .studyRoomList(Arrays.asList(
+                        new CreateStudyRoomRequest(
+                                "Room A",
+                                "작은 룸",
+                                "default-image-url",
+                                7000,
+                                4
+                        ),
+                        new CreateStudyRoomRequest(
+                                "Room B",
+                                "큰 룸",
+                                "default-image-url",
+                                8000,
+                                6
+                        )
+                ))
                 .build();
 
         // When
@@ -295,6 +312,22 @@ class WorkplaceServiceTest {
                     .imageUrl("http://image.url")
                     .workplaceStartTime(LocalTime.of(9, 0))
                     .workplaceEndTime(LocalTime.of(18, 0))
+                    .studyRoomList(Arrays.asList(
+                            new CreateStudyRoomRequest(
+                                    "Room A",
+                                    "작은 룸",
+                                    "default-image-url",
+                                    7000,
+                                    4
+                            ),
+                            new CreateStudyRoomRequest(
+                                    "Room B",
+                                    "큰 룸",
+                                    "default-image-url",
+                                    8000,
+                                    6
+                            )
+                    ))
                     .build();
 
             // When


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 사업장 생성 시 스터디룸 등록 오류 시 예외처리

## 📝 요구 사항과 구현 내용
- 사업장 생성 시 스터디룸 등록 오류 시 예외처리
- 사업장 생성 테스트 코드 수정

## ✅ 피드백 반영사항
- 피드백 받은 내용과 반영된 결과 적기

## 💬 PR 포인트 & 궁금한 점
개선할 수 있는지 궁금합니다
`public void createWorkplace(WorkplaceRequest workplaceDto, Long id) {

        Business business = businessRepository.findById(id).orElseThrow(ErrorCode.BUSINESS_NOT_FOUND::commonException);

        Map<String, BigDecimal> coordinates = getStringBigDecimalMap(workplaceDto);

        Workplace savedWorkplace;

        try {
            Workplace workplace = workplaceDto.toEntity(coordinates.get("latitude"), coordinates.get("longitude"), business);
            workplace.changeStarSum(0L);
            savedWorkplace = workplaceRepository.save(workplace);

        } catch (InvalidDataAccessApiUsageException e) {
            throw ErrorCode.WORKPLACE_INVALID_REQUEST.commonException();
        } catch (Exception e) {
            throw ErrorCode.WORKPLACE_NOT_REGISTERED.commonException();
        }

        saveStudyrooms(workplaceDto, savedWorkplace);
    }`

## 🔗 연관된 이슈