### PR TITLE
✨ feat : 분산락,예약 스케줄링 추가

### DIFF
--- a/src/main/java/roomit/main/domain/reservation/dto/response/ReservationResponse.java
+++ b/src/main/java/roomit/main/domain/reservation/dto/response/ReservationResponse.java
@@ -3,6 +3,7 @@ package roomit.main.domain.reservation.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import roomit.main.domain.reservation.entity.Reservation;
+import roomit.main.domain.reservation.entity.ReservationState;
 import roomit.main.domain.studyroom.entity.StudyRoom;
 import roomit.main.domain.workplace.entity.Workplace;
 import roomit.main.global.service.FileLocationService;
@@ -18,7 +19,8 @@ public record ReservationResponse (
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime endTime,
         Integer reservationCapacity,
         Integer price,
-        Boolean existReview
+        Boolean existReview,
+        ReservationState state
         // LocalDateTime paymentCreatedAt
 ){
     public static ReservationResponse from(StudyRoom studyRoom , Reservation reservation, Workplace workplace, FileLocationService fileLocationService) {
@@ -33,7 +35,9 @@ public record ReservationResponse (
                 reservation.getEndTime(),
                 reservation.getReservationCapacity(),
                 studyRoom.getPrice(),
-                reservation.getReview() != null
+                reservation.getReview() != null,
+                reservation.getReservationState()
+
                 // payment.getCreatedAt()
         );
     }

--- a/src/main/java/roomit/main/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/roomit/main/domain/reservation/repository/ReservationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import roomit.main.domain.reservation.entity.Reservation;
+import roomit.main.domain.reservation.entity.ReservationState;
 
 public interface ReservationRepository extends JpaRepository<Reservation,Long> {
 
@@ -33,6 +34,6 @@ public interface ReservationRepository extends JpaRepository<Reservation,Long> {
     @Query("SELECT r FROM Reservation r WHERE r.studyRoom.studyRoomId = :studyRoomId AND FUNCTION('DATE', r.startTime) = :date")
     List<Reservation> findReservationsByStudyRoomAndDate(@Param("studyRoomId") Long studyRoomId, @Param("date") LocalDate date);
 
-
+    List<Reservation> findByReservationState(ReservationState reservationState);
 }
 

--- a/src/main/java/roomit/main/domain/reservation/service/ReservationScheduler.java
+++ b/src/main/java/roomit/main/domain/reservation/service/ReservationScheduler.java
@@ -1,0 +1,35 @@
+package roomit.main.domain.reservation.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import roomit.main.domain.reservation.entity.Reservation;
+import roomit.main.domain.reservation.entity.ReservationState;
+import roomit.main.domain.reservation.repository.ReservationRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationScheduler {
+
+    private final ReservationRepository reservationRepository;
+
+
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void updateReservationStatus() {
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        List<Reservation> reservations = reservationRepository.findByReservationState(
+                ReservationState.ACTIVE);
+
+        for (Reservation reservation : reservations) {
+            reservation.changeReservationState(ReservationState.COMPLETED);
+            reservationRepository.save(reservation);
+        }
+    }
+}

--- a/src/main/java/roomit/main/domain/reservation/service/ReservationScheduler.java
+++ b/src/main/java/roomit/main/domain/reservation/service/ReservationScheduler.java
@@ -2,6 +2,7 @@ package roomit.main.domain.reservation.service;
 
 import lombok.RequiredArgsConstructor;
 
+import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,15 +15,17 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Log4j2
 public class ReservationScheduler {
 
     private final ReservationRepository reservationRepository;
 
 
-    @Scheduled(cron = "0 0 * * * *")
+    @Scheduled(cron = "0 * * * * *")
     @Transactional
     public void updateReservationStatus() {
         LocalDateTime currentTime = LocalDateTime.now();
+        log.info("스케줄링");
 
         List<Reservation> reservations = reservationRepository.findByReservationState(
                 ReservationState.ACTIVE);

--- a/src/main/java/roomit/main/domain/reservation/service/ReservationService.java
+++ b/src/main/java/roomit/main/domain/reservation/service/ReservationService.java
@@ -51,8 +51,7 @@ public class ReservationService {
     private final FileLocationService fileLocationService;
 
     // 예약 만드는 메서드
-    //@DistributedLock(key = "#studyRoomId + ':' + #request.startTime + ':' + #request.endTime")
-    @Transactional
+    @DistributedLock(key = "#studyRoomId + ':' + #request.startTime + ':' + #request.endTime")
     public Long createReservation(Long memberId,Long studyRoomId,CreateReservationRequest request) {
         validateReservation(request.startTime(),request.endTime());
 

--- a/src/main/java/roomit/main/domain/studyroom/repository/search/SearchStudyRoom.java
+++ b/src/main/java/roomit/main/domain/studyroom/repository/search/SearchStudyRoom.java
@@ -4,5 +4,5 @@ import java.util.List;
 import roomit.main.domain.studyroom.entity.StudyRoom;
 
 public interface SearchStudyRoom {
-  List<StudyRoom> findByWorkPlaceId(List<Long> workplaceIds);
+  List<StudyRoom> findByWorkPlaceId(List<Long> workplaceIds, Integer reservationCapacity);
 }

--- a/src/main/java/roomit/main/domain/studyroom/repository/search/SearchStudyRoomImpl.java
+++ b/src/main/java/roomit/main/domain/studyroom/repository/search/SearchStudyRoomImpl.java
@@ -19,12 +19,13 @@ public class SearchStudyRoomImpl implements SearchStudyRoom {
   }
 
   @Override
-  public List<StudyRoom> findByWorkPlaceId(List<Long> workplaceIds) {
+  public List<StudyRoom> findByWorkPlaceId(List<Long> workplaceIds, Integer reservationCapacity) {
 
     return queryFactory
         .selectFrom(studyRoom)
         .where(
             studyRoom.workPlace.workplaceId.in(workplaceIds)
+                .and(studyRoom.capacity.goe(reservationCapacity))
         )
         .distinct() // 중복 제거
         .fetch();

--- a/src/main/java/roomit/main/domain/studyroom/service/StudyRoomService.java
+++ b/src/main/java/roomit/main/domain/studyroom/service/StudyRoomService.java
@@ -179,7 +179,7 @@ public class StudyRoomService {
             .map(DistanceWorkplaceResponse::workplaceId)
             .toList();
 
-        List<StudyRoom> studyRooms = studyRoomRepository.findByWorkPlaceId(workplaceIds);
+        List<StudyRoom> studyRooms = studyRoomRepository.findByWorkPlaceId(workplaceIds, request.reservationCapacity());
 
         // 예약이 있는 경우에 대해서만 필터링
         return studyRooms.stream()

--- a/src/main/java/roomit/main/global/config/RedissonConfig.java
+++ b/src/main/java/roomit/main/global/config/RedissonConfig.java
@@ -1,0 +1,26 @@
+package roomit.main.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/roomit/main/global/config/security/SpringSecurityConfig.java
+++ b/src/main/java/roomit/main/global/config/security/SpringSecurityConfig.java
@@ -6,8 +6,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -132,7 +130,7 @@ public class SpringSecurityConfig {
                         //정적 리소스 허용
                         .requestMatchers("/css/**", "/js/**", "/images/**", "/static/**", "/index.html").permitAll()
                         //모두 허용
-                        .requestMatchers("/login/**","/").permitAll()
+                        .requestMatchers("/login/**","/", "/health").permitAll()
                         .requestMatchers("/reissue").permitAll()
                         .requestMatchers("/noauth").permitAll()
                         .requestMatchers("/api/v1/member/signup").permitAll()

--- a/src/main/java/roomit/main/global/controller/HealthCheckController.java
+++ b/src/main/java/roomit/main/global/controller/HealthCheckController.java
@@ -1,0 +1,23 @@
+package roomit.main.global.controller;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+  @GetMapping("/health")
+  @ResponseStatus(HttpStatus.OK)
+  public String healthCheck() {
+    return "OK"; // ELB가 200 응답을 기대하므로 간단한 응답
+  }
+
+  @GetMapping("/")
+  @ResponseStatus(HttpStatus.OK)
+  public String rootCheck() {
+    return "OK"; // 루트 경로도 헬스 체크로 사용 가능
+  }
+}

--- a/src/main/java/roomit/main/global/rock/AopForTransaction.java
+++ b/src/main/java/roomit/main/global/rock/AopForTransaction.java
@@ -1,0 +1,17 @@
+package roomit.main.global.rock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction { //트랜잭션 분리를 위한 클래스
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+        //@DistributedLock 이 선언된 메서드는 Propagation.REQUIRES_NEW 옵션을 지정해 부모 트랜잭션의 유무에 관계없이 별도의 트랜잭션으로 동작
+        //그리고 반드시 트랜잭션 커밋 이후 락이 해제되게끔 처리
+    }
+}

--- a/src/main/java/roomit/main/global/rock/CustomSpringELParser.java
+++ b/src/main/java/roomit/main/global/rock/CustomSpringELParser.java
@@ -1,0 +1,22 @@
+package roomit.main.global.rock;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+    //전달받은 Lock의 이름을 Spring Expression Language 로 파싱하여 읽어오는 역할
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/roomit/main/global/rock/DistributedLock.java
+++ b/src/main/java/roomit/main/global/rock/DistributedLock.java
@@ -1,0 +1,33 @@
+package roomit.main.global.rock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/roomit/main/global/rock/DistributedLockAop.java
+++ b/src/main/java/roomit/main/global/rock/DistributedLockAop.java
@@ -22,7 +22,7 @@ public class DistributedLockAop {
     private final RedissonClient redissonClient;
     private final AopForTransaction aopForTransaction;
 
-    @Around("@annotation(roomit.main.global.rock.DistributedLock)")
+    @Around("@annotation(roomit.main.global.rock.DistributedLock)") // DistributedLock 어노테이션이 있는 위치
     public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();

--- a/src/main/java/roomit/main/global/rock/DistributedLockAop.java
+++ b/src/main/java/roomit/main/global/rock/DistributedLockAop.java
@@ -1,0 +1,53 @@
+package roomit.main.global.rock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(roomit.main.global.rock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);  // 락의 이름으로 RLock 인스턴스 가져오기
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            //waitTime까지 획득을 시도, leaseTime이 지나면 잠금을 해제
+            if (!available) {
+                return false;
+            }
+
+            return aopForTransaction.proceed(joinPoint);  // DistributedLock 어노테이션이 선언된 메서드를 별도의 트랜잭션으로 실행
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            try {
+                rLock.unlock();   // 종료 시 무조건 락을 해제
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson Lock Already UnLock serviceName={} key={}", method.getName(), key);
+            }
+        }
+    }
+
+}

--- a/src/main/java/roomit/main/global/token/config/JWTFilter.java
+++ b/src/main/java/roomit/main/global/token/config/JWTFilter.java
@@ -137,6 +137,7 @@ public class JWTFilter extends OncePerRequestFilter {
         // 예외적으로 필터링하지 않을 경로들
         List<String> excludedPaths = List.of(
                 "/",
+                "/health",
                 "/index.html",
                 "/static/**",
                 "/css/**",

--- a/src/test/java/roomit/main/domain/test/ReservationLockTest.java
+++ b/src/test/java/roomit/main/domain/test/ReservationLockTest.java
@@ -1,0 +1,260 @@
+//package roomit.main.domain.test;
+//
+//import jakarta.transaction.Transactional;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.TestInstance;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+//import org.springframework.test.context.ActiveProfiles;
+//import roomit.main.domain.business.dto.request.BusinessRegisterRequest;
+//import roomit.main.domain.business.entity.Business;
+//import roomit.main.domain.business.repository.BusinessRepository;
+//import roomit.main.domain.business.service.BusinessService;
+//import roomit.main.domain.member.entity.Member;
+//import roomit.main.domain.member.entity.Sex;
+//import roomit.main.domain.member.repository.MemberRepository;
+//import roomit.main.domain.reservation.dto.request.CreateReservationRequest;
+//import roomit.main.domain.reservation.entity.Reservation;
+//import roomit.main.domain.reservation.repository.ReservationRepository;
+//import roomit.main.domain.reservation.service.ReservationService;
+//import roomit.main.domain.studyroom.entity.StudyRoom;
+//import roomit.main.domain.studyroom.repository.StudyRoomRepository;
+//import roomit.main.domain.workplace.entity.Workplace;
+//import roomit.main.domain.workplace.repository.WorkplaceRepository;
+//import roomit.main.global.error.ErrorCode;
+//import roomit.main.global.service.ImageService;
+//
+//import java.time.LocalDate;
+//import java.time.LocalDateTime;
+//import java.time.LocalTime;
+//import java.util.NoSuchElementException;
+//import java.util.concurrent.CountDownLatch;
+//import java.util.concurrent.ExecutorService;
+//import java.util.concurrent.Executors;
+//import java.util.stream.IntStream;
+//
+//import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+//
+//@SpringBootTest
+//@ActiveProfiles("test")
+//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+//@Transactional
+//public class ReservationLockTest {
+//
+//    @Autowired
+//    private BusinessService businessService;
+//
+//    @Autowired
+//    private BusinessRepository businessRepository;
+//
+//    @Autowired
+//    private BCryptPasswordEncoder passwordEncoder;
+//
+//    @Autowired
+//    private MemberRepository memberRepository;
+//
+//    @Autowired
+//    private WorkplaceRepository workplaceRepository;
+//
+//    @Autowired
+//    private StudyRoomRepository studyRoomRepository;
+//
+//    @Autowired
+//    private ImageService imageService;
+//
+//    @Autowired
+//    private ReservationService reservationService;
+//
+//    @Autowired
+//    private ReservationRepository reservationRepository;
+//
+//    @Test
+//    @DisplayName("분산락 x")
+//    void test() throws InterruptedException {
+//        LocalDate date = LocalDate.of(2024, 11, 22);
+//
+//        BusinessRegisterRequest businessRegisterRequest = BusinessRegisterRequest.builder()
+//                            .businessName("테스트사업자테스트" )
+//                            .businessEmail("business8543@gmail.com")
+//                            .businessPwd("Business1!")
+//                            .businessNum("122-64-05126")
+//                            .build();
+//
+//                    businessService.signUpBusiness(businessRegisterRequest); // 데이터 생성
+//            Business business = businessRepository.findByBusinessEmail("business8543@gmail.com").orElseThrow(NoSuchElementException::new);
+//
+//        Workplace workplace = Workplace.builder()
+//                .workplaceName("Workplace")
+//                .workplacePhoneNumber("0507-1234-5678")
+//                .workplaceDescription("사업장 설명")
+//                .workplaceAddress("서울 중구 장충단로 247 굿모닝시티 8층")
+//                .imageUrl(imageService.createImageUrl("Workplace"))
+//                .workplaceStartTime(LocalTime.of(9, 0))
+//                .workplaceEndTime(LocalTime.of(18, 0))
+//                .business(business)
+//                .build();
+//        workplaceRepository.save(workplace);
+//
+//        StudyRoom studyRoom = StudyRoom.builder()
+//                .studyRoomName("Test Room")
+//                .description("A test room")
+//                .capacity(10)
+//                .price(100)
+//                .imageUrl(imageService.createImageUrl("Workplace/Test Room"))
+//                .workplace(workplace)
+//                .build();
+//
+//        studyRoomRepository.save(studyRoom);
+//
+//        IntStream.rangeClosed(0, 9).forEach(i -> {
+//            Member member =  Member.builder()
+//                    .birthDay(date)
+//                    .memberSex(Sex.FEMALE)
+//                    .memberPwd("Business1!")
+//                    .memberEmail("wfqdfqwfa"+i+"@naver.com")
+//                    .memberPhoneNumber("010-1323-2154")
+//                    .memberNickName("치킨유저")
+//                    .passwordEncoder(passwordEncoder)
+//                    .build();
+//
+//            memberRepository.save(member);
+//                }
+//        );
+//        String code = "reservationTest";
+//        Long studyRoomId = studyRoom.getStudyRoomId();
+//
+//        int numberOfThreads = 10;
+//        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+//
+//        CreateReservationRequest request = CreateReservationRequest.builder()
+//                .reservationName("예약테스트")
+//                .reservationPhoneNumber("010-1111-2222")
+//                .capacity(4)
+//                .price(50000)
+//                .startTime(LocalDateTime.now())
+//                .endTime(LocalDateTime.now().plusHours(2))
+//                .build();
+//        System.out.println(studyRoomId);
+//        System.out.println(request);
+//
+//        for (int i = 0; i < numberOfThreads; i++) {
+//            Long memberId = memberRepository.findByMemberEmail("wfqdfqwfa" + i + "@naver.com").orElseThrow().getMemberId();
+//            System.out.println(memberId);
+//            executorService.submit(() -> {
+//                try {
+//                    reservationService.createTestLockFalse(memberId,studyRoomId,request);
+//                } catch (Exception e) {
+//                    System.out.println(e.getMessage());
+//                } finally {
+//                    latch.countDown();
+//                }
+//            });
+//        }
+//
+//        latch.await();
+//
+//        Long totalCount = reservationRepository.count();
+//
+//        System.out.println("등록된 예약 = " + totalCount);
+//        assertThat(totalCount).isOne();
+//
+//    }
+//
+//    @Test
+//    @DisplayName("분산락 o")
+//    void test2() throws InterruptedException {
+//        LocalDate date = LocalDate.of(2024, 11, 22);
+//
+//        BusinessRegisterRequest businessRegisterRequest = BusinessRegisterRequest.builder()
+//                .businessName("테스트테스트사업자" )
+//                .businessEmail("business1732@gmail.com")
+//                .businessPwd("Business1!")
+//                .businessNum("643-26-95312")
+//                .build();
+//
+//        businessService.signUpBusiness(businessRegisterRequest); // 데이터 생성
+//        Business business = businessRepository.findByBusinessEmail("business1732@gmail.com").orElseThrow(NoSuchElementException::new);
+//
+//        Workplace workplace = Workplace.builder()
+//                .workplaceName("Workplace")
+//                .workplacePhoneNumber("0507-1234-5678")
+//                .workplaceDescription("사업장 설명")
+//                .workplaceAddress("서울 중구 장충단로 247 굿모닝시티 8층")
+//                .imageUrl(imageService.createImageUrl("Workplace"))
+//                .workplaceStartTime(LocalTime.of(9, 0))
+//                .workplaceEndTime(LocalTime.of(18, 0))
+//                .business(business)
+//                .build();
+//        workplaceRepository.save(workplace);
+//
+//        StudyRoom studyRoom = StudyRoom.builder()
+//                .studyRoomName("Test Room")
+//                .description("A test room")
+//                .capacity(10)
+//                .price(100)
+//                .imageUrl(imageService.createImageUrl("Workplace/Test Room"))
+//                .workplace(workplace)
+//                .build();
+//
+//        studyRoomRepository.save(studyRoom);
+//
+//        IntStream.rangeClosed(0, 9).forEach(i -> {
+//                    Member member =  Member.builder()
+//                            .birthDay(date)
+//                            .memberSex(Sex.FEMALE)
+//                            .memberPwd("Business1!")
+//                            .memberEmail("wfqdfqwf"+i+"@naver.com")
+//                            .memberPhoneNumber("010-1323-2154")
+//                            .memberNickName("치킨유저")
+//                            .passwordEncoder(passwordEncoder)
+//                            .build();
+//
+//                    memberRepository.save(member);
+//                }
+//        );
+//        String code = "reservationTest";
+//        Long studyRoomId = studyRoom.getStudyRoomId();
+//
+//        int numberOfThreads = 10;
+//        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+//
+//        CreateReservationRequest request = CreateReservationRequest.builder()
+//                .reservationName("예약테스트")
+//                .reservationPhoneNumber("010-1111-2222")
+//                .capacity(4)
+//                .price(50000)
+//                .startTime(LocalDateTime.now())
+//                .endTime(LocalDateTime.now().plusHours(2))
+//                .build();
+//        System.out.println(studyRoomId);
+//        System.out.println(request);
+//
+//        String lockName = "예약 등록 키";
+//
+//        for (int i = 0; i < numberOfThreads; i++) {
+//            Long memberId = memberRepository.findByMemberEmail("wfqdfqwf" + i + "@naver.com").orElseThrow().getMemberId();
+//            System.out.println(memberId);
+//            executorService.submit(() -> {
+//                try {
+//                    reservationService.createTestLockSuccess(lockName,memberId,studyRoomId,request);
+//                } catch (Exception e) {
+//                    System.out.println(e.getMessage());
+//                } finally {
+//                    latch.countDown();
+//                }
+//            });
+//        }
+//
+//        latch.await();
+//
+//        Long totalCount = reservationRepository.count();
+//
+//        System.out.println("등록된 예약 = " + totalCount);
+//        assertThat(totalCount).isOne();
+//    }
+//
+//}


### PR DESCRIPTION
## 🛠️ 과제 요약 
- 분산락,예약 스케줄링 추가

## 📝 요구 사항과 구현 내용
- Radisson을 이용한 분산락을 구현하였습니다
>AOP를 이용하여 분산락을 구현하였습니다. jmeter를 통해 테스트를 진행하여 동시 예약시 하나의 예약만 등록 가능하도록 구현하였습니다
- 예약 스케줄링을 추가하였습니다
> 예약의 상태가 현재시간 기준 endTIme이 지나면 예약의 상태가 ACTIVE에서COMPLETED로 변경하기 위해 매 정각마다 예약 상태가 ACTIVE인 예약들을 조회하여 endTime이 지났을경우 COMPLETED로 변경됩니다

## 🔗 연관된 이슈
#168 